### PR TITLE
Added missing Belgium/French OID for SOD

### DIFF
--- a/src/pymrtd/ef/sod.py
+++ b/src/pymrtd/ef/sod.py
@@ -128,6 +128,11 @@ class SODSignedData(cms.MrtdSignedData):
         LDSSecurityObject
     )
     cms.cms_register_encap_content_info_type(
+        "ldsSecurityObject_alt",
+        oids.id_mrtd_ldsSecurityObjectAlt,
+        LDSSecurityObject
+    )
+    cms.cms_register_encap_content_info_type(
         'data',
         oids.id_data,
         _DataChoice
@@ -218,8 +223,11 @@ class SOD(ElementaryFile):
     @classmethod
     def _valid_content_type(cls, ct, strict):
         oid = ct.dotted
-        return oid == oids.id_mrtd_ldsSecurityObject or \
-            (strict == False and oid in cls._allowedSodContentTypes)
+        return (
+            oid == oids.id_mrtd_ldsSecurityObject
+            or oid == oids.id_mrtd_ldsSecurityObjectAlt
+            or (not strict and oid in cls._allowedSodContentTypes)
+        )
 
     def __str__(self):
         """

--- a/src/pymrtd/pki/oids.py
+++ b/src/pymrtd/pki/oids.py
@@ -5,6 +5,9 @@ id_icao_cscaMasterList                 = id_icao_mrtd_security + '.2'  # ICAO 93
 id_icao_cscaMasterListSigningKey       = id_icao_mrtd_security + '.3'  # ICAO 9303-12-p27
 id_icao_mrtd_security_aaProtocolObject = id_icao_mrtd_security + '.5'  # ICAO 9303-11-p38
 
+# PKI for Machine Readable Travel Documents Offering ICC Read-Only Access Version - 1.1, Annex C
+id_mrtd_ldsSecurityObjectAlt = '1.3.27.1.1.1'
+
 # ICAO 9303-11-p37
 bsi_de = '0.4.0.127.0.7'
 


### PR DESCRIPTION
Been running into this issue with Belgium NFC documents and it seems that they are using a different OID. 

> Invalid encapContentInfo type: 1.3.27.1.1.1, expected 2.23.136.1.1.1

```
  /**
   * This TC_SOD_IOD is apparently used in
   * "PKI for Machine Readable Travel Documents Offering ICC Read-Only Access Version - 1.1, Annex C".
   * Seen in live French and Belgian MRTDs.
   *
   * 
   * id-icao-ldsSecurityObjectid OBJECT IDENTIFIER ::=
   *    {iso(1) identified-organization(3) icao(27) atn-end-system-air(1) security(1) ldsSecurityObject(1)}
   * 

   */
  private static final String ICAO_LDS_SOD_ALT_OID = "1.3.27.1.1.1";
  ```
[Source is JMRTD](https://github.com/E3V3A/JMRTD/blob/master/jmrtd/src/org/jmrtd/lds/SODFile.java#L122)