### PR TITLE
Improve signer certificate retrieval logic

### DIFF
--- a/src/pymrtd/pki/cms.py
+++ b/src/pymrtd/pki/cms.py
@@ -256,8 +256,16 @@ class MrtdSignedData(cms.SignedData):
     @staticmethod
     def _get_signer_cert_by_sni(cert_list: CertList, sni: cms.IssuerAndSerialNumber):
         for c in cert_list:
-            if c.serial_number == sni['serial_number'].native and c.issuer == sni['issuer']:
-                return c
+            if c.serial_number == sni['serial_number'].native:
+                found = False
+                for field in sni['issuer'].native:
+                    if field in c.issuer.native:
+                        found = sni['issuer'].native[field] == c.issuer.native[field]
+                    else:
+                        found = False
+                        break
+                if found:
+                    return c
         return None
 
     @staticmethod


### PR DESCRIPTION
Enhance certificate matching by allowing partial issuer field matches.
There are documents where the order of the fields, in ASN1 struct, is different, but the values ​​are identical and therefore the check on == returns False (incorrectly)